### PR TITLE
changed the default group name from "group" to "gel_group"

### DIFF
--- a/config.php
+++ b/config.php
@@ -38,7 +38,7 @@
 	//posts vote table
 	$post_vote_table = "post_votes";
 	//group table
-	$group_table = "groups";
+	$group_table = "gel_groups";
 	//tag historys
 	$tag_history_table = "tag_history";
 	//comment count table


### PR DESCRIPTION
Group is now a reserved word in mysql, so it should be avoided as the default name
It gave me issues with my local server running the site when I updated mysql and several features (image removal, profile, etc) all stopped working.